### PR TITLE
switch to predictoor v2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 web3
 eth-account
 pathlib
+eth-keys


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- use authorization to fetch predictions
- use template2 style when ordering


Requires  oceanprotocol/ocean-contracts:predictoor2 image